### PR TITLE
Improve SEO metadata and WebSite structured data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,6 +41,7 @@ export const metadata: Metadata = {
   authors: [{ name: 'Ura' }],
   creator: 'Ura',
   alternates: {
+    canonical: '/',
     types: {
       'application/rss+xml': '/feed.xml',
       'application/atom+xml': '/atom.xml'
@@ -53,13 +54,22 @@ export const metadata: Metadata = {
     siteName: 'Uralog',
     title: 'Uralog',
     description:
-      'React、Next.js、TypeScriptを使ったフロントエンド開発の技術記事やプログラミングに関する知識を発信するエンジニアブログです。'
+      'React、Next.js、TypeScriptを使ったフロントエンド開発の技術記事やプログラミングに関する知識を発信するエンジニアブログです。',
+    images: [
+      {
+        url: '/api/og',
+        width: 1200,
+        height: 630,
+        alt: 'Uralog'
+      }
+    ]
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Uralog',
     description:
-      'React、Next.js、TypeScriptを使ったフロントエンド開発の技術記事やプログラミングに関する知識を発信するエンジニアブログです。'
+      'React、Next.js、TypeScriptを使ったフロントエンド開発の技術記事やプログラミングに関する知識を発信するエンジニアブログです。',
+    images: ['/api/og']
   },
   robots: {
     index: true,

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,3 +1,5 @@
+import { SOCIAL_LINKS } from '@/constants/sns'
+
 import { BASE_URL } from './envs'
 
 import type { Post } from './post'
@@ -53,6 +55,16 @@ export function generateWebSiteStructuredData() {
       name: 'Ura',
       url: BASE_URL
     },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Uralog',
+      logo: {
+        '@type': 'ImageObject',
+        url: `${BASE_URL}/ura-icon.png`
+      }
+    },
+    image: `${BASE_URL}/api/og`,
+    sameAs: [SOCIAL_LINKS.github.href, SOCIAL_LINKS.zenn.href, SOCIAL_LINKS.x.href],
     potentialAction: {
       '@type': 'SearchAction',
       target: {


### PR DESCRIPTION
### Motivation
- Improve homepage SEO and social preview metadata and provide richer WebSite structured data for search engines.

### Description
- Added canonical and OpenGraph/Twitter image metadata to `src/app/layout.tsx` by setting `alternates.canonical`, `openGraph.images`, and `twitter.images` pointing to the `/api/og` endpoint.
- Enriched `generateWebSiteStructuredData` in `src/lib/structured-data.ts` by importing `SOCIAL_LINKS` and adding `publisher`, `image`, and `sameAs` (social profiles) fields.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aee8edd48832f9f1f20e2f3e168d0)